### PR TITLE
Fix for FireFox "SecurityError: The operation is insecure." if an external CSS ref is present

### DIFF
--- a/jquery.rule.js
+++ b/jquery.rule.js
@@ -206,9 +206,6 @@
 	},function( m, a ){
 		var many = a == rules;//the rules need some more processing
 		$.fn[m] = function(){
-			return this.map(function(){
-				return many ? $.makeArray(this[a]) : this[a];
-			});
 		};
 	});
 	

--- a/jquery.rule.js
+++ b/jquery.rule.js
@@ -206,6 +206,9 @@
 	},function( m, a ){
 		var many = a == rules;//the rules need some more processing
 		$.fn[m] = function(){
+			return this.map(function(){
+				return many ? $.makeArray(this[a]) : this[a];
+			});
 		};
 	});
 	

--- a/jquery.rule.js
+++ b/jquery.rule.js
@@ -207,7 +207,24 @@
 		var many = a == rules;//the rules need some more processing
 		$.fn[m] = function(){
 			return this.map(function(){
-				return many ? $.makeArray(this[a]) : this[a];
+        var prop;
+        try {
+          // In Chrome, if stylesheet originates from a different domain,
+          // ss.cssRules simply won't exist. I believe the same is true for IE, but
+          // I haven't tested it.
+          //
+          // In Firefox, if stylesheet originates from a different domain, trying
+          // to access ss.cssRules will throw a SecurityError. Hence, we must use
+          // try/catch to detect this condition in Firefox.
+          prop = this[a];
+        } catch(e) {
+          // Rethrow exception if it's not a SecurityError. Note that SecurityError
+          // exception is specific to Firefox.
+          if(e.name !== 'SecurityError')
+            throw e;
+          prop = null;
+        }
+        return many ? $.makeArray(prop) : prop;
 			});
 		};
 	});


### PR DESCRIPTION
Only in FireFox, if we try to access the "cssRule" attribute that belongs to an external resource, let's say, a Google Font CSS ref, FireFox will throw an exception and stop execution of the plugin. This fix follows a [discussion on StackOverflow](http://stackoverflow.com/a/23613052/366662) around the same problem.

So far, Internet Explorer, Safari (on iOS) and Chrome did not had problems with this exception, and returns "null". The simple fact of accessing this object property was enough to cause the exception on FireFox.

This pull fixes this problem by adding a `try/catch` around. The problem went away and tests did not identify any change on the plugin behaviour.

_(There were more commits then it should be as I made a mistake on my git commands)_