### PR TITLE
Update rules check style

### DIFF
--- a/jquery.rule.js
+++ b/jquery.rule.js
@@ -84,7 +84,7 @@
 				case 'object':
 					if( ss[0] ) ss = ss[0];
 					if( ss[sheet] ) ss = ss[sheet];
-					if( ss[rules] ) break;//only if the stylesheet is valid
+					if( ss.hasOwnProperty(rules) ) break;//only if the stylesheet is valid
 				default:
 					if( typeof r == 'object' ) return r;//let's not waist time, it is parsed
 					ss = storage;


### PR DESCRIPTION
This is apparently a security issue with stylesheets served from a different origin (for example, from a CDN). Dereferencing the `rules` property in this way is disallowed, but we may ask whether the property exists. Here's an example where others encountered the issue:

https://github.com/odoo/odoo/issues/22517#issuecomment-361217543